### PR TITLE
[PR#23] navigation stack TabView 바깥으로 이동

### DIFF
--- a/NanaLand/NanaLand.xcodeproj/project.pbxproj
+++ b/NanaLand/NanaLand.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		2C40DB9A2BE64973007A3768 /* NanaHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C40DB992BE64973007A3768 /* NanaHome.swift */; };
 		2C40DB9C2BE66809007A3768 /* AuthDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C40DB9B2BE66809007A3768 /* AuthDTO.swift */; };
 		2C40DB9E2BE87C61007A3768 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C40DB9D2BE87C61007A3768 /* Color+.swift */; };
+		2C40DBB42BECE671007A3768 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C40DBB32BECE671007A3768 /* UINavigationController+.swift */; };
+		2C40DBB62BECEE2A007A3768 /* UITabBarController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C40DBB52BECEE2A007A3768 /* UITabBarController+.swift */; };
 		2C80EC9E2BCE53E1002F38A7 /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80EC9D2BCE53E1002F38A7 /* Article.swift */; };
 		2C80ECA02BCE55E0002F38A7 /* ArticleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80EC9F2BCE55E0002F38A7 /* ArticleItem.swift */; };
 		2C80ECA82BCF5CF2002F38A7 /* SearchAllCategoryResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80ECA72BCF5CF2002F38A7 /* SearchAllCategoryResultView.swift */; };
@@ -171,6 +173,8 @@
 		2C40DB992BE64973007A3768 /* NanaHome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NanaHome.swift; sourceTree = "<group>"; };
 		2C40DB9B2BE66809007A3768 /* AuthDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDTO.swift; sourceTree = "<group>"; };
 		2C40DB9D2BE87C61007A3768 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		2C40DBB32BECE671007A3768 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		2C40DBB52BECEE2A007A3768 /* UITabBarController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+.swift"; sourceTree = "<group>"; };
 		2C80EC9D2BCE53E1002F38A7 /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		2C80EC9F2BCE55E0002F38A7 /* ArticleItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleItem.swift; sourceTree = "<group>"; };
 		2C80ECA72BCF5CF2002F38A7 /* SearchAllCategoryResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAllCategoryResultView.swift; sourceTree = "<group>"; };
@@ -573,6 +577,8 @@
 				2C80ECB62BCFA055002F38A7 /* Data+.swift */,
 				2C80ECF12BDBE545002F38A7 /* YearMonthDay+.swift */,
 				2C40DB9D2BE87C61007A3768 /* Color+.swift */,
+				2C40DBB32BECE671007A3768 /* UINavigationController+.swift */,
+				2C40DBB52BECEE2A007A3768 /* UITabBarController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -860,6 +866,7 @@
 				2C40DB9C2BE66809007A3768 /* AuthDTO.swift in Sources */,
 				BF9834252BCE847300A5C289 /* HomeMainViewModel.swift in Sources */,
 				BF98341B2BCE71DB00A5C289 /* ShopMainView.swift in Sources */,
+				2C40DBB62BECEE2A007A3768 /* UITabBarController+.swift in Sources */,
 				BF9842F12BCE897C00D6A60C /* BannerModel.swift in Sources */,
 				2C3C75C92BCA550200312F26 /* UtilSample.swift in Sources */,
 				BF3021EC2BDF8D9500CB3966 /* ShopDetailModel.swift in Sources */,
@@ -869,6 +876,7 @@
 				2C80EC9E2BCE53E1002F38A7 /* Article.swift in Sources */,
 				BF9F02952BD8A6AD003E72E6 /* FestivalDetailView.swift in Sources */,
 				2C3C75BF2BCA53EE00312F26 /* HomeMainView.swift in Sources */,
+				2C40DBB42BECE671007A3768 /* UINavigationController+.swift in Sources */,
 				2C40DB832BE62259007A3768 /* LanguageSelectView.swift in Sources */,
 				2C1F31D52BCD2A870066819F /* NanaSearchBar.swift in Sources */,
 				BF7C0EC02BD0B725008ACB75 /* secret.swift in Sources */,

--- a/NanaLand/NanaLand/App/AppState.swift
+++ b/NanaLand/NanaLand/App/AppState.swift
@@ -9,5 +9,4 @@ import SwiftUI
 
 class AppState: ObservableObject {
 	@Published var currentTab: Tab = .home
-    @Published var isTabViewHidden: Bool = false
 }

--- a/NanaLand/NanaLand/App/NanaLandTabView.swift
+++ b/NanaLand/NanaLand/App/NanaLandTabView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUIIntrospect
 
 enum Tab {
 	case home, favorite, story, profile
@@ -15,107 +14,45 @@ enum Tab {
 struct NanaLandTabView: View {
 	@EnvironmentObject var appState: AppState
     var body: some View {
-		TabView(selection: $appState.currentTab) {
-			HomeMainView()
-				.tabItem {
-					Label(
-						title: { Text(String(localized: "home")).font(.gothicNeo(.semibold, size: 10)) },
-						icon: { appState.currentTab == .home ? Image(.icHomeFill) : Image(.icHome) }
-					)
-				}
-				.tag(Tab.home)
-			
-			FavoriteMainView()
-				.tabItem {
-					Label(
-						title: { Text(String(localized: "favorite")).font(.gothicNeo(.semibold, size: 10)) },
-						icon: { appState.currentTab == .favorite ? Image(.icHeartFill) : Image(.icHeart) }
-					)
-				}
-				.tag(Tab.favorite)
-			
-			StoryMainView()
-                .tabItem {
-                    Label(
-                        title: { Text("제주 이야기").font(.gothicNeo(.semibold, size: 10)) },
-                        icon: { appState.currentTab == .story ? Image(.icStoryFill) : Image(.icStory) }
-                    )
-                }
-                .tag(Tab.story)
-            
-            ProfileMainView()
-                .tabItem {
-                    Label(
-                        title: { Text("나의 나나").font(.gothicNeo(.semibold, size: 10)) },
-                        icon: { appState.currentTab == .profile ? Image(.icMyPageFill) : Image(.icMyPage) }
-                    )
-                }
-                .tag(Tab.profile)
-        }
-        .tint(.baseBlack)
-        .introspect(.tabView, on: .iOS(.v16, .v17)) { tabView in
-            let appearance = UITabBarAppearance()
-            if appState.isTabViewHidden == true {
-                appearance.configureWithTransparentBackground()
-                tabView.tabBar.standardAppearance = appearance
-                
-                tabView.tabBar.backgroundColor = UIColor.red
-                
-                tabView.tabBar.layer.masksToBounds = true
-                tabView.tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-                tabView.tabBar.layer.cornerRadius = 16
-                if let shadowView = tabView.view.subviews.first(where: { $0.accessibilityIdentifier == "TabBarShadow" }) {
-                    shadowView.frame = tabView.tabBar.frame
-                } else {
-                    let shadowView = UIView(frame: .zero)
-                    shadowView.frame = .zero
-                    shadowView.accessibilityIdentifier = "TabBarShadow"
-                    
-                    shadowView.backgroundColor = UIColor.yellow
-                    
-                    shadowView.layer.cornerRadius = tabView.tabBar.layer.cornerRadius
-                    shadowView.layer.maskedCorners = tabView.tabBar.layer.maskedCorners
-                    shadowView.layer.masksToBounds = false
-                    shadowView.layer.shadowColor = Color.black.cgColor
-                    shadowView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-                    shadowView.layer.shadowOpacity = 0.1
-                    shadowView.layer.shadowRadius = 10
-                    tabView.view.addSubview(shadowView)
-                    tabView.view.bringSubviewToFront(tabView.tabBar)
-                    
-                }
-            }
-            else {
-                appearance.configureWithTransparentBackground()
-                tabView.tabBar.standardAppearance = appearance
-                
-                tabView.tabBar.backgroundColor = UIColor.white
-                
-                tabView.tabBar.layer.masksToBounds = true
-                tabView.tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-                tabView.tabBar.layer.cornerRadius = 16
-                
-                if let shadowView = tabView.view.subviews.first(where: { $0.accessibilityIdentifier == "TabBarShadow" }) {
-                    shadowView.frame = tabView.tabBar.frame
-                } else {
-                    let shadowView = UIView(frame: .zero)
-                    shadowView.frame = tabView.tabBar.frame
-                    shadowView.accessibilityIdentifier = "TabBarShadow"
-                    
-                    shadowView.backgroundColor = UIColor.clear
-                    
-                    shadowView.layer.cornerRadius = tabView.tabBar.layer.cornerRadius
-                    shadowView.layer.maskedCorners = tabView.tabBar.layer.maskedCorners
-                    shadowView.layer.masksToBounds = false
-                    shadowView.layer.shadowColor = Color.black.cgColor
-                    shadowView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-                    shadowView.layer.shadowOpacity = 0.1
-                    shadowView.layer.shadowRadius = 10
-                    tabView.view.addSubview(shadowView)
-                    tabView.view.bringSubviewToFront(tabView.tabBar)
-                }
-                
-            }
+		NavigationStack {
+			TabView(selection: $appState.currentTab) {
+				HomeMainView()
+					.tabItem {
+						Label(
+							title: { Text(String(localized: "home")).font(.gothicNeo(.semibold, size: 10)) },
+							icon: { appState.currentTab == .home ? Image(.icHomeFill) : Image(.icHome) }
+						)
+					}
+					.tag(Tab.home)
+				
+				FavoriteMainView()
+					.tabItem {
+						Label(
+							title: { Text(String(localized: "favorite")).font(.gothicNeo(.semibold, size: 10)) },
+							icon: { appState.currentTab == .favorite ? Image(.icHeartFill) : Image(.icHeart) }
+						)
+					}
+					.tag(Tab.favorite)
+				
+				StoryMainView()
+					.tabItem {
+						Label(
+							title: { Text("제주 이야기").font(.gothicNeo(.semibold, size: 10)) },
+							icon: { appState.currentTab == .story ? Image(.icStoryFill) : Image(.icStory) }
+						)
+					}
+					.tag(Tab.story)
+				
+				ProfileMainView()
+					.tabItem {
+						Label(
+							title: { Text("나의 나나").font(.gothicNeo(.semibold, size: 10)) },
+							icon: { appState.currentTab == .profile ? Image(.icMyPageFill) : Image(.icMyPage) }
+						)
+					}
+					.tag(Tab.profile)
+			}
 		}
+        .tint(.baseBlack)
     }
 }

--- a/NanaLand/NanaLand/Extension/UINavigationController+.swift
+++ b/NanaLand/NanaLand/Extension/UINavigationController+.swift
@@ -1,0 +1,20 @@
+//
+//  UINavigationController+.swift
+//  NanaLand
+//
+//  Created by 정현우 on 5/9/24.
+//
+import UIKit
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+	override open func viewDidLoad() {
+		super.viewDidLoad()
+		// 뒤로 가기 제스쳐 활성화
+		interactivePopGestureRecognizer?.delegate = self
+	}
+
+	public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+		// stack에 view가 1개 보다 많은경우만 pop
+		return viewControllers.count > 1
+	}
+}

--- a/NanaLand/NanaLand/Extension/UITabBarController+.swift
+++ b/NanaLand/NanaLand/Extension/UITabBarController+.swift
@@ -1,0 +1,17 @@
+//
+//  UITabBarController+.swift
+//  NanaLand
+//
+//  Created by 정현우 on 5/9/24.
+//
+
+import UIKit
+
+extension UITabBarController {
+	open override func viewWillLayoutSubviews() {
+		super.viewWillLayoutSubviews()
+		// TODO: tabBar custom
+//		self.tabBar.layer.masksToBounds = true
+//		self.tabBar.layer.cornerRadius = 12
+	}
+}

--- a/NanaLand/NanaLand/Home/HomeMainView.swift
+++ b/NanaLand/NanaLand/Home/HomeMainView.swift
@@ -11,186 +11,179 @@ import SwiftUIIntrospect
 
 struct HomeMainView: View {
 
-  @StateObject var viewModel = HomeMainViewModel()
-	@ObservedObject var searchVM = SearchViewModel()
-
+	@StateObject var viewModel = HomeMainViewModel()
     
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    HStack(spacing: 0) {
-                        Button(action: {
-                            print("button1")
-                        }) {
-                            Image("icLogo")
-                                
-                        }
-                        .padding(.leading, 16)
-                        Spacer()
-                        NavigationLink(destination: SearchMainView()) {
-                           Text("제주도는 지금 유채꽃 축제🏵️")
-                                .padding()
-                                .frame(width: 278, alignment: .leading)
-                                .font(.gothicNeo(size: 14, font: "mid"))
-                                .foregroundStyle(Color("Gray1"))
-                                .overlay(RoundedRectangle(cornerRadius: 30)
-                                    .stroke(Color("Main"))
-                                )
-                        }
-                        Spacer()
-                        
-                        Button(action: {
-                            print("alarm")
-                        }) {
-                            Image("icBell")
-                        }
-                        .padding(.trailing, 16)
-                        
-                    }
-                    .padding(.bottom, 16)
-                        
-                    
-                    /// banner View
-                        BannerView()
-                        .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width / 2)
-                            .padding(.bottom)
-                    
-                    /// category View
-                    HStack(spacing: 12) {
-                        // 7대자연 link
-                        NavigationLink(destination: NatureMainView()) {
-                            VStack(spacing: 0) {
-                                Image("icNature")
-                                    .frame(width: 62, height: 48)
-                                   
-                                Text("7대자연")
-                                    .font(.gothicNeo(size: 12, font: "semibold"))
-                                    .tint(.black)
-                            }
-                        }
-                        
-                        // 축제 link
-                        NavigationLink(destination: FestivalMainView()) {
-                            VStack(spacing: 0) {
-                                Image("icFestival")
-                                    .frame(width: 62, height: 48)
-                                    
-                                Text("축제")
-                                    .font(.gothicNeo(size: 12, font: "semibold"))
-                                    .tint(.black)
-                            }
-                        }
-                        .frame(height: 65)
-                
-                        // 전통시장 link
-                        NavigationLink(destination: ShopMainView()) {
-                            VStack(spacing: 0) {
-                                Image("icShop")
-                                    .frame(width: 62, height: 48)
-                       
-                                Text("전통시장")
-                                    .font(.gothicNeo(size: 12, font: "semibold"))
-                                    .tint(.black)
-                            }
-                        }
-                        .frame(height: 65)
-                   
-                        // 이색체험 link
-                        NavigationLink(destination: ExperienceMainView()) {
-                            VStack(spacing: 0) {
-                                Image("icExp")
-                                    .frame(width: 62, height: 48)
-                                Text("이색 체험")
-                                    .font(.gothicNeo(size: 12, font: "semibold"))
-                                    .tint(.black)
-                            }
-                        }
-                        .frame(height: 65)
-                    
-                        // 나나 Pick link
-                        NavigationLink(destination: NanapickMainView()) {
-                            VStack(spacing: 0) {
-                                Image("icNana")
-                                    .frame(width: 62, height: 48)
-                                 
-                                Text(String(localized: "nanaPick"))
-                                    .font(.gothicNeo(size: 12, font: "semibold"))
-                                    .tint(.black)
-                            }
-                        }
-                        .frame(height: 65)
-                       
-                    }
-                    .frame(width: UIScreen.main.bounds.width)
-                    .padding(.bottom, 5)
-                
-                    /// 광고 뷰
-                    HStack {
-                        AdvertisementView()
-                            .background(.yellow)
-                            .frame(height: (UIScreen.main.bounds.width - 40.0) * (80.0 / 328.0))
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .padding(.bottom, 40)
-                            .padding(.leading, 16)
-                            .padding(.trailing, 16)
-                    }
-                    
-                    HStack {
-                        Text("감자마케터 님을 위한 도민 추천 🍊")
-                            .font(.gothicNeo(size: 18, font: "bold"))
-                        Spacer()
-                    }
-                    .padding(.leading, 16)
-                    .padding(.bottom, 8)
-
-                    HStack(spacing: 8) {
-                        if let responseData = viewModel.recommendResponseData {
-                            // 첫번째 추천 게시물
-                            let firstItem = responseData.data[0]
-                            // 두번째 추천 게시물
-                            let secondItem = responseData.data[1]
-                            VStack(alignment: .leading, spacing: 8) {
-                                KFImage(URL(string: firstItem.thumbnailUrl)!)
-                                    .resizable()
-                                    .frame(height: (UIScreen.main.bounds.width - 40) / 2 * (118 / 160))
-                                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                                Text(firstItem.title)
-                                    .font(.gothicNeo(size: 14, font: "bold"))
-                                Text(firstItem.intro)
-                                    .font(.gothicNeo(.medium, size: 12))
-                                    .foregroundStyle(Color(.gray1))
-                            }
-                             
-                            VStack(alignment: .leading, spacing: 8) {
-                                KFImage(URL(string: secondItem.thumbnailUrl)!)
-                                    .resizable()
-                                    .frame(height: (UIScreen.main.bounds.width - 40) / 2 * (118 / 160))
-                                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                                   
-                                Text(secondItem.title)
-                                    .font(.gothicNeo(size: 14, font: "bold"))
-                                Text(secondItem.intro)
-                                    .font(.gothicNeo(.medium, size: 12))
-                                    .foregroundStyle(Color(.gray1))
-                                   
-                            }
-                        }
-                    }
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                }
-            }
-        }
-		.environmentObject(searchVM)
-        .onAppear {
-             viewModel.recommendFetchData()
-        }
-        .introspect(.navigationStack, on: .iOS(.v16, .v17), customize: { navigation in
-                    navigation.hidesBottomBarWhenPushed = true
-                })
-        
-    }
+	var body: some View {
+		ScrollView {
+			VStack(spacing: 0) {
+				HStack(spacing: 0) {
+					Button(action: {
+						print("button1")
+					}) {
+						Image("icLogo")
+						
+					}
+					.padding(.leading, 16)
+					Spacer()
+					NavigationLink(
+						destination: SearchMainView()
+					) {
+						Text("제주도는 지금 유채꽃 축제🏵️")
+							.padding()
+							.frame(width: 278, alignment: .leading)
+							.font(.gothicNeo(size: 14, font: "mid"))
+							.foregroundStyle(Color("Gray1"))
+							.overlay(RoundedRectangle(cornerRadius: 30)
+								.stroke(Color("Main"))
+							)
+					}
+					Spacer()
+					
+					Button(action: {
+						print("alarm")
+					}) {
+						Image("icBell")
+					}
+					.padding(.trailing, 16)
+					
+				}
+				.padding(.bottom, 16)
+				
+				
+				/// banner View
+				BannerView()
+					.frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width / 2)
+					.padding(.bottom)
+				
+				/// category View
+				HStack(spacing: 12) {
+					// 7대자연 link
+					NavigationLink(destination: NatureMainView()) {
+						VStack(spacing: 0) {
+							Image("icNature")
+								.frame(width: 62, height: 48)
+							
+							Text("7대자연")
+								.font(.gothicNeo(size: 12, font: "semibold"))
+								.tint(.black)
+						}
+					}
+					
+					// 축제 link
+					NavigationLink(destination: FestivalMainView()) {
+						VStack(spacing: 0) {
+							Image("icFestival")
+								.frame(width: 62, height: 48)
+							
+							Text("축제")
+								.font(.gothicNeo(size: 12, font: "semibold"))
+								.tint(.black)
+						}
+					}
+					.frame(height: 65)
+					
+					// 전통시장 link
+					NavigationLink(destination: ShopMainView()) {
+						VStack(spacing: 0) {
+							Image("icShop")
+								.frame(width: 62, height: 48)
+							
+							Text("전통시장")
+								.font(.gothicNeo(size: 12, font: "semibold"))
+								.tint(.black)
+						}
+					}
+					.frame(height: 65)
+					
+					// 이색체험 link
+					NavigationLink(destination: ExperienceMainView()) {
+						VStack(spacing: 0) {
+							Image("icExp")
+								.frame(width: 62, height: 48)
+							Text("이색 체험")
+								.font(.gothicNeo(size: 12, font: "semibold"))
+								.tint(.black)
+						}
+					}
+					.frame(height: 65)
+					
+					// 나나 Pick link
+					NavigationLink(destination: NanapickMainView()) {
+						VStack(spacing: 0) {
+							Image("icNana")
+								.frame(width: 62, height: 48)
+							
+							Text(String(localized: "nanaPick"))
+								.font(.gothicNeo(size: 12, font: "semibold"))
+								.tint(.black)
+						}
+					}
+					.frame(height: 65)
+					
+				}
+				.frame(width: UIScreen.main.bounds.width)
+				.padding(.bottom, 5)
+				
+				/// 광고 뷰
+				HStack {
+					AdvertisementView()
+						.background(.yellow)
+						.frame(height: (UIScreen.main.bounds.width - 40.0) * (80.0 / 328.0))
+						.clipShape(RoundedRectangle(cornerRadius: 10))
+						.padding(.bottom, 40)
+						.padding(.leading, 16)
+						.padding(.trailing, 16)
+				}
+				
+				HStack {
+					Text("감자마케터 님을 위한 도민 추천 🍊")
+						.font(.gothicNeo(size: 18, font: "bold"))
+					Spacer()
+				}
+				.padding(.leading, 16)
+				.padding(.bottom, 8)
+				
+				HStack(spacing: 8) {
+					if let responseData = viewModel.recommendResponseData {
+						// 첫번째 추천 게시물
+						let firstItem = responseData.data[0]
+						// 두번째 추천 게시물
+						let secondItem = responseData.data[1]
+						VStack(alignment: .leading, spacing: 8) {
+							KFImage(URL(string: firstItem.thumbnailUrl)!)
+								.resizable()
+								.frame(height: (UIScreen.main.bounds.width - 40) / 2 * (118 / 160))
+								.clipShape(RoundedRectangle(cornerRadius: 12))
+							Text(firstItem.title)
+								.font(.gothicNeo(size: 14, font: "bold"))
+							Text(firstItem.intro)
+								.font(.gothicNeo(.medium, size: 12))
+								.foregroundStyle(Color(.gray1))
+						}
+						
+						VStack(alignment: .leading, spacing: 8) {
+							KFImage(URL(string: secondItem.thumbnailUrl)!)
+								.resizable()
+								.frame(height: (UIScreen.main.bounds.width - 40) / 2 * (118 / 160))
+								.clipShape(RoundedRectangle(cornerRadius: 12))
+							
+							Text(secondItem.title)
+								.font(.gothicNeo(size: 14, font: "bold"))
+							Text(secondItem.intro)
+								.font(.gothicNeo(.medium, size: 12))
+								.foregroundStyle(Color(.gray1))
+							
+						}
+					}
+				}
+				.padding(.leading, 16)
+				.padding(.trailing, 16)
+			}
+		}
+		.onAppear {
+			viewModel.recommendFetchData()
+		}
+	}
 }
 
 struct AdvertisementView: View {

--- a/NanaLand/NanaLand/Home/Search/View/SearchMainView.swift
+++ b/NanaLand/NanaLand/Home/Search/View/SearchMainView.swift
@@ -10,7 +10,7 @@ import Kingfisher
 
 struct SearchMainView: View {
 	@Environment(\.dismiss) var dismiss
-	@EnvironmentObject var searchVM: SearchViewModel
+	@StateObject var searchVM: SearchViewModel = SearchViewModel()
 	
 	@State var searchTerm = ""
 	@State var showResultView: Bool = false
@@ -29,14 +29,15 @@ struct SearchMainView: View {
 				Spacer()
 					.frame(height: 100)
 			}
+			
 		}
 		.toolbar(.hidden, for: .navigationBar)
-		.navigationDestination(isPresented: $showResultView) {
-			SearchResultView(searchTerm: searchTerm)
-		}
 		.task {
 			await searchVM.action(.getPopularKeyword)
 			await searchVM.action(.getVolumeUp)
+		}
+		.navigationDestination(isPresented: $showResultView) {
+			SearchResultView(searchVM: searchVM, searchTerm: searchTerm)
 		}
     }
 	

--- a/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchAllCategoryResultView.swift
+++ b/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchAllCategoryResultView.swift
@@ -8,29 +8,33 @@
 import SwiftUI
 
 struct SearchAllCategoryResultView: View {
-	@EnvironmentObject var searchVM: SearchViewModel
+	@ObservedObject var searchVM: SearchViewModel
 	
 	var body: some View {
 		ScrollView(.vertical, showsIndicators: false) {
 			SearchAllCategoryItem(
+				searchVM: searchVM,
 				category: .nature,
 				count: searchVM.state.allCategorySearchResult.nature.totalElements,
 				articles: searchVM.state.allCategorySearchResult.nature.data
 			)
 			
 			SearchAllCategoryItem(
+				searchVM: searchVM,
 				category: .festival,
 				count: searchVM.state.allCategorySearchResult.festival.totalElements,
 				articles: searchVM.state.allCategorySearchResult.festival.data
 			)
 			
 			SearchAllCategoryItem(
+				searchVM: searchVM,
 				category: .market,
 				count: searchVM.state.allCategorySearchResult.market.totalElements,
 				articles: searchVM.state.allCategorySearchResult.market.data
 			)
 			
 			SearchAllCategoryItem(
+				searchVM: searchVM,
 				category: .experience,
 				count: searchVM.state.allCategorySearchResult.experience.totalElements,
 				articles: searchVM.state.allCategorySearchResult.experience.data
@@ -44,7 +48,7 @@ struct SearchAllCategoryResultView: View {
 }
 
 struct SearchAllCategoryItem: View {
-	@EnvironmentObject var searchVM: SearchViewModel
+	@ObservedObject var searchVM: SearchViewModel
 	
 	let category: Category
 	let count: Int
@@ -116,6 +120,5 @@ struct SearchAllCategoryItem: View {
 }
 
 #Preview {
-    SearchAllCategoryResultView()
-		.environmentObject(SearchViewModel())
+	SearchAllCategoryResultView(searchVM: SearchViewModel())
 }

--- a/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchDetailCategoryResultView.swift
+++ b/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchDetailCategoryResultView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SearchDetailCategoryResultView: View {
-	@EnvironmentObject var searchVM: SearchViewModel
+	@ObservedObject var searchVM: SearchViewModel
 	
 	let tab: Category
 	let searchTerm: String
@@ -84,6 +84,5 @@ struct SearchDetailCategoryResultView: View {
 }
 
 #Preview {
-	SearchDetailCategoryResultView(tab: .experience, searchTerm: "제주시")
-		.environmentObject(SearchViewModel())
+	SearchDetailCategoryResultView(searchVM: SearchViewModel(), tab: .experience, searchTerm: "제주시")
 }

--- a/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchResultView.swift
+++ b/NanaLand/NanaLand/Home/Search/View/SearchResult/SearchResultView.swift
@@ -40,7 +40,7 @@ enum Category: String, CaseIterable, Codable {
 
 struct SearchResultView: View {
 	@Environment(\.dismiss) var dismiss
-	@EnvironmentObject var searchVM: SearchViewModel
+	@ObservedObject var searchVM: SearchViewModel
 	
 	@State var searchTerm: String
 	
@@ -112,10 +112,10 @@ struct SearchResultView: View {
 	
 	private var contentTab: some View {
 		TabView(selection: $searchVM.state.currentSearchTab) {
-			SearchAllCategoryResultView()
+			SearchAllCategoryResultView(searchVM: searchVM)
 				.tag(Category.all)
 			
-			SearchDetailCategoryResultView(tab: .nature, searchTerm: searchTerm)
+			SearchDetailCategoryResultView(searchVM: searchVM, tab: .nature, searchTerm: searchTerm)
 				.tag(Category.nature)
 				.onAppear {
 					if !isNatureSearchIsDone {
@@ -127,7 +127,7 @@ struct SearchResultView: View {
 					}
 				}
 			
-			SearchDetailCategoryResultView(tab: .festival, searchTerm: searchTerm)
+			SearchDetailCategoryResultView(searchVM: searchVM, tab: .festival, searchTerm: searchTerm)
 				.tag(Category.festival)
 				.onAppear {
 					if !isFestivalSearchIsDone {
@@ -138,7 +138,7 @@ struct SearchResultView: View {
 					}
 				}
 			
-			SearchDetailCategoryResultView(tab: .market, searchTerm: searchTerm)
+			SearchDetailCategoryResultView(searchVM: searchVM, tab: .market, searchTerm: searchTerm)
 				.tag(Category.market)
 				.onAppear {
 					if !isMarketSearchIsDone {
@@ -149,7 +149,7 @@ struct SearchResultView: View {
 					}
 				}
 			
-			SearchDetailCategoryResultView(tab: .experience, searchTerm: searchTerm)
+			SearchDetailCategoryResultView(searchVM: searchVM, tab: .experience, searchTerm: searchTerm)
 				.tag(Category.experience)
 				.onAppear {
 					if !isExperienceSearchIsDone {
@@ -168,6 +168,5 @@ struct SearchResultView: View {
 }
 
 #Preview {
-	SearchResultView(searchTerm: "")
-		.environmentObject(SearchViewModel())
+	SearchResultView(searchVM: SearchViewModel(), searchTerm: "")
 }

--- a/NanaLand/NanaLand/Shop/ShopMainView.swift
+++ b/NanaLand/NanaLand/Shop/ShopMainView.swift
@@ -48,14 +48,8 @@ struct ShopMainView: View {
             
             Spacer()
         }
-        .onAppear {
-            appState.isTabViewHidden = true
-        }
         .toolbar(.hidden)
-        .toolbar(.hidden, for: .tabBar)
-        .onDisappear {
-            appState.isTabViewHidden = false
-        }
+
     }
 
 }


### PR DESCRIPTION
# 작업 내용
- navigationStack TabView 밖으로 이동
- Figma 상 TabBar 커스텀 사라자셔 코드 지웠습니다.
- 후에 커스텀 필요하다면 UITabBarController 사용하시면 될 것 같습니다.

# 상의하고 싶은 내용
1. 
- 기존 HomeMainView에 NavigationStack이 있어서 SearchViewModel을 해당 stack에 environmentObject로 뿌려줬습니다.
- 하지만 이번에 NavigaionStack이 앱 전체에 1개만 있으므로 이 stack전체에 SearchViewModel을 공유하는 것은 불필요하다 생각했습니다.
- .environmnetObject는 stack 전체에 뿌려주는거 아니면 navigation했을때 인식을 못하더라구요
- 따라서 기존 @EnvironmentObject로 SearchVM을 받아 사용했는데 이걸 매번 ObservedObject로 subView에 넘겨줬습니다.

2.
- 위에서 말씀 드린 내용을 처음엔 ObservedObject이 아닌 StateObject로 넘겨줬더니 app이 freeze났습니다.

이런저런 이슈로 일단 이렇게 구현했는데 이게 맞는 구조인지는 모르겠네요.
UIKit처럼 여러개의 NavigationStack이 가능했으면 좋았을 것 같네요😅